### PR TITLE
Update 25/01/06

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "4",
   "specifiers": {
     "jsr:@davidbonnet/astring@1.8.6": "1.8.6",
+    "jsr:@hono/hono@4.6.15": "4.6.15",
     "jsr:@std/cli@1.0.9": "1.0.9",
     "jsr:@std/cli@^1.0.8": "1.0.9",
     "jsr:@std/collections@^1.0.9": "1.0.9",
@@ -29,6 +30,7 @@
     "jsr:@std/toml@^1.0.1": "1.0.2",
     "jsr:@std/yaml@1.0.5": "1.0.5",
     "jsr:@std/yaml@^1.0.5": "1.0.5",
+    "npm:@imagemagick/magick-wasm@0.0.31": "0.0.31",
     "npm:@js-temporal/polyfill@0.4.4": "0.4.4",
     "npm:date-fns@4.1.0": "4.1.0",
     "npm:estree-walker@3.0.3": "3.0.3",
@@ -42,6 +44,9 @@
   "jsr": {
     "@davidbonnet/astring@1.8.6": {
       "integrity": "98b4914c8863cdf8c0ff83bb5c528caa67a8dca6020ad6234113499f00583e3a"
+    },
+    "@hono/hono@4.6.15": {
+      "integrity": "935b3b12e98e4b22bcd1aa4dbe6587321e431c79829eba61f535b4ede39fd8b1"
     },
     "@std/cli@1.0.9": {
       "integrity": "557e5865af000efbf3f737dcfea5b8ab86453594f4a9cd8d08c9fa83d8e3f3bc"
@@ -142,6 +147,9 @@
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
       ]
+    },
+    "@imagemagick/magick-wasm@0.0.31": {
+      "integrity": "sha512-QNivAUxSaItuiY8ziI/vRy6TtoecD7TOsD1LGZCG3wv8lfbdGbIj2QiJk0FlGkGwAVR966NlD3mkxPNvQrvq0w=="
     },
     "@js-temporal/polyfill@0.4.4": {
       "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
@@ -488,10 +496,53 @@
     }
   },
   "remote": {
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/adapters/lume.ts": "ce2f4c68b1461bd9f208c31c61196fda8d60086cac441af1e7cde10c3683555d",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/cms.ts": "0fcf7ab9ddcc90637c915052e6ab5375d11d49bf827c59c3b6c1fcc3aa408c1a",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/collection.ts": "0c95ac5d5e52e110453b40fb494ac7ae3179f6f775e9a5a6e708e9e86027c435",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/document.ts": "b27c476b51b963443ed897fc474cf8b75cc8b4e40c6cf32e21af8d4117996c9a",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/git.ts": "a61a3a41b8c736d1f0db1bf580c862a83d95803f5a74bc17af68e62c7e6aff00",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/routes/auth.ts": "b9a5c5b77169a3c5be46aa8dba15a187ed1dc2f6c9c8fb71ba35782e39cd2044",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/routes/collection.ts": "1f6d266ff18c853c8f5bfefddab88cf6817e9964cb1afed336c5e11cdd93c479",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/routes/document.ts": "5f9b01893b4f435dd64d28d16c647b3ed7373fcc56f6a658420850348198109f",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/routes/files.ts": "1716c7735c580b3eb911a92e1e76d86f6dc2693cfcad7fdc860f41745def586f",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/routes/index.ts": "d140a7577b88ab06a1a401e1a91334c6e56b8988adc6635443db822a5bf214e9",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/routes/versions.ts": "dcfd34b50fb0be72078915ae484a6c23868366c0afcbdc88d7cb4c1910c161c1",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/breadcrumb.ts": "4252e88ab5aec21ce7f460cdb7cd29fd17a88cdd676817a0c09a9a15cad4d290",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/collection/create.ts": "2903e057465875ebe9e3b0f8ed2856698191811272b697daeae244e8f3fc9666",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/collection/edit.ts": "e91947b53960c846d7cea4727b5abf8b1de50ba5dfe0837854992cf8212271c6",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/collection/list.ts": "df7a060747bfa55ff5bceeb5a24d55906dbfcc1c554eccf9d314f5601b29aa8b",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/document/edit.ts": "72a448c521630a8566e33a03d25df0f3447f9a3ac1bfbcf56b38d11e86dc70a3",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/index.ts": "126d31eb590363f76e0a396368396cf572026edb4e451889f9719637f9e4467b",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/layout.ts": "c0dd3a7de89f06aa6157eaa290a80c5aba71896f3944c7d87ece6fb005d64362",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/notfound.ts": "c89b3b113a6cd847b7dfa6155688c01e8e53754e5f0548149971ae5da5c439cd",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/tree.ts": "55fe000dafd47f1a6e91ff6aa879146f3a3812e7adf9e993b2602bb9e8b4ea98",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/uploads/create.ts": "af5660b40812756ffd22c413b8a42966ca120c8df3c0b3333ab83db06c675684",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/uploads/crop.ts": "b6eb513a9deb6a310bff9a83b28acecb31f508789f9f29a0d1a514579de2bff5",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/uploads/list.ts": "408a34d76f2459c76d7328faf4257a13c70f19d8a891f62a00f4c565d67694f5",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/templates/uploads/view.ts": "a1ec958adeb803aa947e5048ea174c071408ca6fa7a9a9cd6a8500c83a93df1f",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/upload.ts": "9d68f3274bc480be0f5ffc4fc65b7c2354c5b269f70c1579dad9aaa964111728",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/utils/data.ts": "b7e2dcd3f07b142aba97e5540741fd0724d583dd4d6ec12115e3907ae6258025",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/utils/env.ts": "723cb01d9509e0942a32ff568314b5ac27152c94e0070dc0cd6a706c74f33a62",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/utils/event.ts": "a7915a3e6bf7b34c166ee3aefc8ca5aab1631de50e0d851f78d0e8c8d0c766d8",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/utils/path.ts": "cd949fd0db7ca4bc8f05abbaa8a1398868784c424b6edff953a29ee8f6c87490",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/core/utils/string.ts": "e826d6f2cde988cab51a2fff326123bd72ca8c90b676f203dd248bf93e3eb5df",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/deps/hono.ts": "e5a28c120c29ea1098f36a2383e4d22e07466271feed1c61838b3d7636661fb8",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/deps/imagick.ts": "e2054263419bad3a1a58e391b2ca007aaa9d33f66bc7c149c6f8f217b73c869a",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/deps/std.ts": "6c24e5f8c7329ef588924a4aaa100a0dbcaf1a7e4c847dd265843fe05fce2d1e",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/fields/core.ts": "57f007bc90c5a72efcd5b7cf5c446032229b09ea793e1859d48957ae55658b2e",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/mod.ts": "8c0e794889d779e84137f4d3b9673f5a5a1083777afdffa571d0a7af54ddceac",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/storage/fs.ts": "2d45319ce0ece128c6a86dbff4f18d392d07a641c0bf1b8d616b0ae4d63fec92",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/storage/transformers/front_matter.ts": "d0809292ae1ccb367c7e7852a2b6bd383e4da531ff95da4a640afa181412fe0d",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/storage/transformers/json.ts": "eb5d664be2042cc266a4fc737bbeeb1b4eb586e2beab8ca1965b07c2b066ee68",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/storage/transformers/mod.ts": "d828136358c98c93b45b5a1f1c7f383f9788ec47ede04bcb03de8ee0b19c2b3c",
+    "https://cdn.jsdelivr.net/gh/lumeland/cms@8091117168e698cc6d83a98b4e87d9e0bcb62852/storage/transformers/yaml.ts": "87ce4b914a91ecec833558c29a5bbe8ca33f5cdf05141ba5e9c4e497aace561c",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli.ts": "dcdc9d6abc1a219f1b972772ba27be33cebeffebb3db2d82a3f3d752d789a758",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/build.ts": "a3acda3c702d6a51a8fe65ea3abc17813deea0db71e442de6120a747f56a2466",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/build_worker.ts": "a96cb2f66e28a91e5e2e8c231b10942d03528eb6971ed6bf679828b223323dd6",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/cms.ts": "7f3f46c3353661a7679926d0ddcfe3e596f3c97ad2de7f535bde5906e42c3f5a",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/cms_worker.ts": "d1941da4fa63ab025812e9565818f976e53015aac8e06149f6dbab869b836f75",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/create.ts": "f340056e3b01a61007f82b47a174ede55df2d80d343e492a3853d44007bb8fc6",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/missing_worker_apis.ts": "70625ded7fee5de7d215e0829ce8dc4bb7060f6a496c09db880ebaec8b3efb92",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/run.ts": "27e7c84c2bcadc3aa4ca4fbad02330f33000dca9a2ef41780bad3676606bc029",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/upgrade.ts": "a11e7c9024f78c2e7376c57b4a99e389dbf490769779d2d37a4a3ccd6ef27d9e",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/cli/utils.ts": "4697e4280ff62b537507ed707ec84ea707b0519f8de32e2e762f498104a8d1ae",
@@ -527,6 +578,7 @@
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/lume_config.ts": "4c2f26fae6a562dcfc40d224137caaf783d52fe8e10813892f1a2c6ca1f79d2f",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/lume_version.ts": "96ce8c0144b5adbc170f388b60be706244d1bd100413e748e9cf23878838c87c",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/merge_data.ts": "a574d97eeaa1513d30440488f52e988f0fe2085397611852673cea10076f01ff",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/net.ts": "982f86aa708272642f65a9086f2af2553cfedcd9f55bc675dce5c44bdc91e208",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/object.ts": "e00ee6e91264064772c87e69e128a09ba0e30c2c41be4a5302881f59f456fc31",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/page_content.ts": "e7d4323a7b66d1ae26c1263dd5a13a0c5e9f73583c9cf83454ad61f157d8351d",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/core/utils/page_date.ts": "2a3d9c203df298ca61f568fdf509945f127f990769623c3edfd753d39807b757",
@@ -560,7 +612,12 @@
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/deps/toml.ts": "cc55b94f0c44e4113ff09e153e8b1c58bc5f585b7ea1e8f14f96c8152241b166",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/deps/vento.ts": "eb2e423fc23983c04d73fd03c86627179c58bb2c385709dc5e8e1b253b16cf5f",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/deps/yaml.ts": "cbcf4d295ed88066e12a718750f09cebbf30fefa32e186844b597bce74b35557",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/middlewares/logger.ts": "c96f1a9f9d5757555b6f141865ce8551ac176f90c8ee3e9ad797b2b400a9a567",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/middlewares/no_cache.ts": "0119e3ae3a596ab12c42df693b93e5b03dd9608e289d862242751a9739438f35",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/middlewares/no_cors.ts": "4d24619b5373c98bcc3baf404db47ba088c87ac8538ea1784e58d197b81d4d02",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/middlewares/not_found.ts": "4507842d422267062c34662dceab17affcaad01858a5890fda163a8ddeb31487",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/middlewares/reload.ts": "ec723e917bd12c83f65fc39a66592add9ec2ab56a1ad17f429ba749d32c218f9",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/middlewares/reload_client.js": "992ac4a2f4a9fb4a1ab5f23f674ef202a43d73652cdebcf7b1552b482a7410ef",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/mod.ts": "097c8497b7bc917b3558f87611b21fa0507d4ad28b863fd41a9bf7683aed1042",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/plugins/date.ts": "d92823f67326e4f5d73d8cda2e357d36c07a30f4824d95b9402ae4202b336e0c",
     "https://cdn.jsdelivr.net/gh/lumeland/lume@891f286f1e001b8bdd0c4edcdac637522855e202/plugins/fff.ts": "48f1fc52aee3e4f39fda8a8163b465383d8140a5d913d8709b28164c9bce4525",
@@ -700,6 +757,7 @@
     "https://deno.land/x/fff@v1.2.1/src/utils/presets/strict.ts": "98af4eafd001c370aa7b149e4d9ca2903a3d7d330eafc889b10c612f8c441e8a",
     "https://deno.land/x/fff@v1.2.1/src/utils/ptd.ts": "994605e705b6a99ad94e69b28876923c2f993535e753602ccb75ff943073506e",
     "https://deno.land/x/fff@v1.2.1/src/utils/transform.ts": "a6cbe098dfbbf990ad9700fee197bde4d3bee309e60eb9fe8add5c8d5778ec42",
+    "https://deno.land/x/imagemagick_deno@0.0.31/mod.ts": "124d7f045429f6e6c486b86e72d025410d09576bc0d8075e69f97118a1a33413",
     "https://deno.land/x/vento@v1.12.14/deps.ts": "47ad104c87a32292e978f0fba4f69954f7feff3b403833858e1cc51c5313e9db",
     "https://deno.land/x/vento@v1.12.14/mod.ts": "cfaac455f70af8e59aa0c03ef39b641635094225255f0fbaa76f4771e683f2ca",
     "https://deno.land/x/vento@v1.12.14/plugins/echo.ts": "59adb9137e736029cf18e3d95e010803c8728046d0d040702c16c4930c7b6160",

--- a/src/404.md
+++ b/src/404.md
@@ -1,3 +1,3 @@
 # 404 Page not found
 
-Sorry, we could not find that page, go back to [Home](/)
+Sorry, we could not find that page, you can go back to the [homepage](/).

--- a/src/_data.toml
+++ b/src/_data.toml
@@ -20,7 +20,7 @@ generator = true
 
 [license]
 name = "CC BY-ND 4.0"
-link = "https://https://creativecommons.org/licenses/by-nd/4.0/"
+link = "https://creativecommons.org/licenses/by-nd/4.0/"
 full = " Creative Commons Attribution-NoDerivatives 4.0 International"
 icon = '<img style="height:20px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:20px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" alt=""><img style="height:20px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg?ref=chooser-v1" alt=""></a>'
 
@@ -31,9 +31,10 @@ image_height = 300
 name="Projects"
 link="/project"
 
-[[header_nav]]
-name="Skills"
-link="/skills"
+# TODO
+# [[header_nav]]
+# name="Skills"
+# link="/skills"
 
 [[header_nav]]
 name="About"
@@ -79,16 +80,19 @@ icon="images/skills/svelte-color.svg"
 ssg = {name = "Lume", link = "https://lume.land"}
 
 [[footer.nav]]
-name="Blog"
-link="https://surajssingh.github.io/Tech-Tree-Blog/"
-
-[[footer.nav]]
 name="GitHub"
 link="https://github.com/SurajSSingh"
+icon={catalog="simpleicons", name="github", alt="GitHub Logo"}
 
 [[footer.nav]]
 name="LinkedIn"
 link="https://www.linkedin.com/in/suraj-s-singh/"
+icon={catalog="simpleicons", name="linkedin", alt="LinkedIn Logo"}
+
+[[footer.nav]]
+name="Blog"
+link="https://thetechtreeblog.com"
+icon = {catalog="assets", name="images/tech-tree-blog-icon.svg", alt="Tech Tree Blog Logo", width=24}
 
 [[footer.stylings]]
 name = "Chota"

--- a/src/_includes/layouts/resume/components/experience.pug
+++ b/src/_includes/layouts/resume/components/experience.pug
@@ -5,7 +5,7 @@ section#education
         each role in exp.roles
             - let roleAccomplishments = private_accomplishments.filter(accList => accList.key === role.key).flatMap(accList => accList.accomplishments);
             - let indices = includedAccomplishmentLists.filter(indList => indList.role === role.key).flatMap(indList => indList.indices);
-            - let accomplishments = indices.map(i => roleAccomplishments[i])
+            - let accomplishments = indices.map(i => roleAccomplishments[i] || `NOTHING @ INDEX #${i}`)
             hgroup
                 h3.text-base.mt-2 #[strong= role.title]
                 p.text-right.text-sm.-mt-5: em= role.start.year + " — " + (role.end ? role.end.year : "Present")

--- a/src/_includes/layouts/resume/components/headline.pug
+++ b/src/_includes/layouts/resume/components/headline.pug
@@ -3,15 +3,15 @@
 mixin add_contact_element(contact)
     case contact
         when "email"
-            a(href="mailto:"+emailContact).underline.underline-offset-4="Email: "+emailContact
+            a(href="mailto:"+emailContact).underline-offset-4="Email: "+emailContact
         when "phone"
             ="Phone: "+private_contacts.phone[headlineExtra.phoneIndex || 0]
         when "github"
-            a(href=general.headline.contact.github).underline.underline-offset-4="GitHub: "+general.headline.contact.github.replace(/^https?\:\/\/(?:www\.)?github.com\//i, "GitHub: ")
+            a(href=general.headline.contact.github).underline-offset-4="GitHub: "+general.headline.contact.github.replace(/^https?\:\/\/(?:www\.)?github.com\//i, "GitHub: ")
         when "linkedin"
-            a(href=general.headline.contact.linkedin).underline.underline-offset-4="LinkedIn: "+general.headline.contact.linkedin.replace(/^https?\:\/\/(?:www\.)?linkedin.com\/in\//i, "LinkedIn: ")
+            a(href=general.headline.contact.linkedin).underline-offset-4="LinkedIn: "+general.headline.contact.linkedin.replace(/^https?\:\/\/(?:www\.)?linkedin.com\/in\//i, "LinkedIn: ")
         when "website"
-            a(href=general.headline.contact.website).underline.underline-offset-4="Website: "+general.headline.contact.website.replace(/^https?\:\/\//i, "")
+            a(href=general.headline.contact.website).underline-offset-4="Website: "+general.headline.contact.website.replace(/^https?\:\/\//i, "")
         default
             span=headlineExtra.contactOrder
 

--- a/src/_includes/layouts/resume/components/skills_list.pug
+++ b/src/_includes/layouts/resume/components/skills_list.pug
@@ -3,4 +3,4 @@ section#education
     hr.border-emerald-100.mb-1
     ul.text-sm.grid.grid-cols-2.grid-flow-row.justify-stretch.mt-1
         each set in skillSet
-            li #[strong.text-right= set.category] #[span.pl-2= set.skills.join(', ')]
+            li #[strong.text-right= set.category]:#[span.pl-1= set.skills.join(', ')]

--- a/src/_includes/layouts/resume/one_column.pug
+++ b/src/_includes/layouts/resume/one_column.pug
@@ -3,6 +3,7 @@ extends resume_layout.pug
 block content
     .bg-emerald-0
         include ./components/headline
+        hr.border-1.my-1.border-emerald-300
         include ./components/summary
     hr.border-2.border-emerald-200
     include ./components/experience

--- a/src/_includes/layouts/resume/one_column_skill_focus.pug
+++ b/src/_includes/layouts/resume/one_column_skill_focus.pug
@@ -2,6 +2,7 @@ extends resume_layout.pug
 
 block content
     include ./components/headline
+    hr
     include ./components/summary
     hr
     include ./components/skills_list

--- a/src/_includes/layouts/resume/resume_layout.pug
+++ b/src/_includes/layouts/resume/resume_layout.pug
@@ -9,7 +9,7 @@ html(lang="en")
     meta(name="author" content=general.headline.name)
     meta(name="description" content=description||"Resume")
     //- meta(name="keywords" content="HTML, CSS, JavaScript")
-    title=title
+    title=general.headline.name.replaceAll(/\.|\s+/g, '')+"-"+title
   body(style="font-family: 'Lato', 'Open Sans';")
     main#content
       block content

--- a/src/_includes/layouts/website/components/footer.vto
+++ b/src/_includes/layouts/website/components/footer.vto
@@ -1,5 +1,17 @@
 <footer class="hide-pr text-center">
     <p><a href="#top">Back to Top</a></p>
+    <div>
+        <p>Some places you can find me: </p>
+        {{ for item of footer.nav }}
+            <a href="{{item.link}}">
+                {{ if item.icon.catalog === "assets" }}
+                    <img src="{{assets}}/{{item.icon.name}}" title="{{item.name}}" alt="{{item.alt}}" width={{item.icon.width || 24}}>
+                {{ else }}
+                    <img src="{{item.icon.name |> icon(item.icon.catalog)}}" title="{{item.name}}" alt="{{item.alt}}" width={{item.icon.width || 24}} fill="var(--color-primary)" inline>
+                {{ /if }}
+            </a>
+        {{ /for }}
+    </div>
     <p>Made with <a href="{{footer.ssg.link}}">{{footer.ssg.name}}</a> and styled with 
         {{ for item of footer.stylings.slice(0,-1) }}
             <a href="{{item.link}}">{{item.name}}</a>, 

--- a/src/_includes/layouts/website/components/header.vto
+++ b/src/_includes/layouts/website/components/header.vto
@@ -17,7 +17,7 @@
                 {{ /for }}
             </div>
             <div class="nav-right">
-                <button id="theme-switch" onclick="switchMode(this)" class="pull-right button bg-grey bd-dark">theme</button>
+                <button id="theme-switch" onclick="switchMode(this)" class="pull-right button bg-primary bd-dark">theme</button>
             </div>
         </div>
     </nav>

--- a/src/assets/images/tech-tree-blog-icon.svg
+++ b/src/assets/images/tech-tree-blog-icon.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="Icon.svg"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 11.288891 11.28889"
+   height="32pt"
+   width="32pt">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     lock-margins="false"
+     units="pt"
+     fit-margin-bottom="5.34684"
+     fit-margin-right="3.943505"
+     fit-margin-left="3.943505"
+     fit-margin-top="5.34684"
+     inkscape:window-maximized="0"
+     inkscape:window-y="25"
+     inkscape:window-x="0"
+     inkscape:window-height="815"
+     inkscape:window-width="1252"
+     inkscape:snap-global="false"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="11.596526"
+     inkscape:cx="5.1850036"
+     inkscape:zoom="5.259532"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0.22861139,1.3167346)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,3.8094929,0.04214004)"
+       id="g853"
+       style="fill:none;stroke:green;stroke-width:2;stroke-linecap:round;stroke-linejoin:round">
+      <circle
+         cx="18"
+         cy="18"
+         r="3"
+         id="circle833" />
+      <circle
+         cx="6"
+         cy="6"
+         r="3"
+         id="circle835" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 13,6 h 3 a 2,2 0 0 1 2,2 v 7"
+         id="path837" />
+      <line
+         x1="6"
+         y1="9"
+         x2="6"
+         y2="21"
+         id="line839" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,3.8482629,0.05485404)"
+       id="g872"
+       style="fill:none;stroke:green;stroke-width:2;stroke-linecap:round;stroke-linejoin:round">
+      <circle
+         cx="18"
+         cy="18"
+         r="3"
+         id="circle855" />
+      <circle
+         cx="6"
+         cy="6"
+         r="3"
+         id="circle857" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 6,21 V 9 a 9,9 0 0 0 9,9"
+         id="path859" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,0.63340288,0.04034504)"
+       id="g894"
+       style="fill:none;stroke:green;stroke-width:2;stroke-linecap:round;stroke-linejoin:round">
+      <line
+         x1="6"
+         y1="3"
+         x2="6"
+         y2="15"
+         id="line874" />
+      <circle
+         cx="18"
+         cy="6"
+         r="3"
+         id="circle876" />
+      <circle
+         cx="6"
+         cy="18"
+         r="3"
+         id="circle878" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 18,9 A 9,9 0 0 1 9,18"
+         id="path880" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,2.2801129,3.587992)"
+       id="g915"
+       style="fill:none;stroke:green;stroke-width:2;stroke-linecap:round;stroke-linejoin:round">
+      <circle
+         cx="12"
+         cy="12"
+         r="4"
+         id="circle898" />
+      <line
+         x1="1.05"
+         y1="12"
+         x2="7"
+         y2="12"
+         id="line900" />
+      <line
+         x1="17.01"
+         y1="12"
+         x2="22.959999"
+         y2="12"
+         id="line902" />
+    </g>
+  </g>
+</svg>

--- a/src/index.md
+++ b/src/index.md
@@ -5,7 +5,7 @@ summary: "Homepage of my website"
 
 exclude_brand: true
 headline: "Suraj S. Singh Portfolio"
-quick_about: "Hi, I'm Suraj, a creative software developer, focused on creating engaging games and interactive media that not only entertains but also educates."
+quick_about: "Hi, I'm Suraj, a creative software developer, focused on creating engaging games and interactive media that not only entertains but also educates. I strive to make knowledge accessible to all. As a lifelong learner, developer, and educator, I am driven to developing engaging and interactive learning environments that simplifies complex concepts and builds meaningful connections between people and the content they are learning. Whether it is through video games, interactive websites, or online articles, I want to be at the forefront of sharing what we know."
 
 priority: 1
 alternative_paths: ["home"]


### PR DESCRIPTION
Includes these small updates:
- Fix Creative Commons link (remove duplicate `https://`)
- Update footer icons and links to now link to external places (no longer linked in header tab), includes logo from simple-icons and custom for blog
- Update theme switcher
- Update resume templates